### PR TITLE
Initial abstraction of Trace Identifiers (api module only).

### DIFF
--- a/api/src/main/java/io/opencensus/trace/BlankSpan.java
+++ b/api/src/main/java/io/opencensus/trace/BlankSpan.java
@@ -38,7 +38,7 @@ public final class BlankSpan extends Span {
   public static final BlankSpan INSTANCE = new BlankSpan();
 
   private BlankSpan() {
-    super(SpanContext.INVALID, null);
+    super(SpanContextImpl.INVALID, null);
   }
 
   /** No-op implementation of the {@link Span#putAttribute(String, AttributeValue)} method. */

--- a/api/src/main/java/io/opencensus/trace/Link.java
+++ b/api/src/main/java/io/opencensus/trace/Link.java
@@ -67,7 +67,7 @@ public abstract class Link {
    * @since 0.5
    */
   public static Link fromSpanContext(SpanContext context, Type type) {
-    return new AutoValue_Link(context.getTraceId(), context.getSpanId(), type, EMPTY_ATTRIBUTES);
+    return new AutoValue_Link(context, type, EMPTY_ATTRIBUTES);
   }
 
   /**
@@ -82,27 +82,12 @@ public abstract class Link {
   public static Link fromSpanContext(
       SpanContext context, Type type, Map<String, AttributeValue> attributes) {
     return new AutoValue_Link(
-        context.getTraceId(),
-        context.getSpanId(),
+        context,
         type,
         Collections.unmodifiableMap(new HashMap<String, AttributeValue>(attributes)));
   }
 
-  /**
-   * Returns the {@code TraceId}.
-   *
-   * @return the {@code TraceId}.
-   * @since 0.5
-   */
-  public abstract TraceId getTraceId();
-
-  /**
-   * Returns the {@code SpanId}.
-   *
-   * @return the {@code SpanId}
-   * @since 0.5
-   */
-  public abstract SpanId getSpanId();
+  public abstract SpanContext getSpanContext();
 
   /**
    * Returns the {@code Type}.

--- a/api/src/main/java/io/opencensus/trace/Sampler.java
+++ b/api/src/main/java/io/opencensus/trace/Sampler.java
@@ -43,8 +43,8 @@ public abstract class Sampler {
   public abstract boolean shouldSample(
       @Nullable SpanContext parentContext,
       @Nullable Boolean hasRemoteParent,
-      TraceId traceId,
-      SpanId spanId,
+      Object traceId,
+      Object spanId,
       String name,
       List<Span> parentLinks);
 

--- a/api/src/main/java/io/opencensus/trace/SpanContext.java
+++ b/api/src/main/java/io/opencensus/trace/SpanContext.java
@@ -29,69 +29,15 @@ import javax.annotation.concurrent.Immutable;
  * @since 0.5
  */
 @Immutable
-public final class SpanContext {
-  private static final Tracestate TRACESTATE_DEFAULT = Tracestate.builder().build();
-  private final TraceId traceId;
-  private final SpanId spanId;
-  private final TraceOptions traceOptions;
-  private final Tracestate tracestate;
+public abstract class SpanContext {
+  protected final TraceOptions traceOptions;
+  protected final Tracestate tracestate;
 
-  /**
-   * The invalid {@code SpanContext}.
-   *
-   * @since 0.5
-   */
-  public static final SpanContext INVALID =
-      new SpanContext(TraceId.INVALID, SpanId.INVALID, TraceOptions.DEFAULT, TRACESTATE_DEFAULT);
+  public abstract String toTraceId();
 
-  /**
-   * Creates a new {@code SpanContext} with the given identifiers and options.
-   *
-   * @param traceId the trace identifier of the span context.
-   * @param spanId the span identifier of the span context.
-   * @param traceOptions the trace options for the span context.
-   * @return a new {@code SpanContext} with the given identifiers and options.
-   * @deprecated use {@link #create(TraceId, SpanId, TraceOptions, Tracestate)}.
-   */
-  @Deprecated
-  public static SpanContext create(TraceId traceId, SpanId spanId, TraceOptions traceOptions) {
-    return create(traceId, spanId, traceOptions, TRACESTATE_DEFAULT);
-  }
+  public abstract String toSpanId();
 
-  /**
-   * Creates a new {@code SpanContext} with the given identifiers and options.
-   *
-   * @param traceId the trace identifier of the span context.
-   * @param spanId the span identifier of the span context.
-   * @param traceOptions the trace options for the span context.
-   * @param tracestate the trace state for the span context.
-   * @return a new {@code SpanContext} with the given identifiers and options.
-   * @since 0.16
-   */
-  public static SpanContext create(
-      TraceId traceId, SpanId spanId, TraceOptions traceOptions, Tracestate tracestate) {
-    return new SpanContext(traceId, spanId, traceOptions, tracestate);
-  }
-
-  /**
-   * Returns the trace identifier associated with this {@code SpanContext}.
-   *
-   * @return the trace identifier associated with this {@code SpanContext}.
-   * @since 0.5
-   */
-  public TraceId getTraceId() {
-    return traceId;
-  }
-
-  /**
-   * Returns the span identifier associated with this {@code SpanContext}.
-   *
-   * @return the span identifier associated with this {@code SpanContext}.
-   * @since 0.5
-   */
-  public SpanId getSpanId() {
-    return spanId;
-  }
+  public abstract boolean isValid();
 
   /**
    * Returns the {@code TraceOptions} associated with this {@code SpanContext}.
@@ -113,53 +59,9 @@ public final class SpanContext {
     return tracestate;
   }
 
-  /**
-   * Returns true if this {@code SpanContext} is valid.
-   *
-   * @return true if this {@code SpanContext} is valid.
-   * @since 0.5
-   */
-  public boolean isValid() {
-    return traceId.isValid() && spanId.isValid();
-  }
-
-  @Override
-  public boolean equals(@Nullable Object obj) {
-    if (obj == this) {
-      return true;
-    }
-
-    if (!(obj instanceof SpanContext)) {
-      return false;
-    }
-
-    SpanContext that = (SpanContext) obj;
-    return traceId.equals(that.traceId)
-        && spanId.equals(that.spanId)
-        && traceOptions.equals(that.traceOptions);
-  }
-
-  @Override
-  public int hashCode() {
-    return Arrays.hashCode(new Object[] {traceId, spanId, traceOptions});
-  }
-
-  @Override
-  public String toString() {
-    return "SpanContext{traceId="
-        + traceId
-        + ", spanId="
-        + spanId
-        + ", traceOptions="
-        + traceOptions
-        + "}";
-  }
-
-  private SpanContext(
-      TraceId traceId, SpanId spanId, TraceOptions traceOptions, Tracestate tracestate) {
-    this.traceId = traceId;
-    this.spanId = spanId;
-    this.traceOptions = traceOptions;
-    this.tracestate = tracestate;
+  protected SpanContext(TraceOptions traceOptions, Tracestate tracestate)
+  {
+      this.traceOptions = traceOptions;
+      this.tracestate = tracestate;
   }
 }

--- a/api/src/main/java/io/opencensus/trace/SpanContextImpl.java
+++ b/api/src/main/java/io/opencensus/trace/SpanContextImpl.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2016-17, OpenCensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opencensus.trace;
+
+import java.util.Arrays;
+import javax.annotation.Nullable;
+import javax.annotation.concurrent.Immutable;
+
+// NOTE: This would be moved to impl_core.
+@Immutable
+public final class SpanContextImpl extends SpanContext {
+  private static final Tracestate TRACESTATE_DEFAULT = Tracestate.builder().build();
+  private final TraceId traceId;
+  private final SpanId spanId;
+
+  /**
+   * The invalid {@code SpanContext}.
+   *
+   * @since 0.5
+   */
+  public static final SpanContext INVALID =
+      new SpanContextImpl(TraceId.INVALID, SpanId.INVALID, TraceOptions.DEFAULT, TRACESTATE_DEFAULT);
+
+  /**
+   * Creates a new {@code SpanContext} with the given identifiers and options.
+   *
+   * @param traceId the trace identifier of the span context.
+   * @param spanId the span identifier of the span context.
+   * @param traceOptions the trace options for the span context.
+   * @return a new {@code SpanContext} with the given identifiers and options.
+   * @deprecated use {@link #create(TraceId, SpanId, TraceOptions, Tracestate)}.
+   */
+  @Deprecated
+  public static SpanContext create(TraceId traceId, SpanId spanId, TraceOptions traceOptions) {
+    return create(traceId, spanId, traceOptions, TRACESTATE_DEFAULT);
+  }
+
+  /**
+   * Creates a new {@code SpanContext} with the given identifiers and options.
+   *
+   * @param traceId the trace identifier of the span context.
+   * @param spanId the span identifier of the span context.
+   * @param traceOptions the trace options for the span context.
+   * @param tracestate the trace state for the span context.
+   * @return a new {@code SpanContext} with the given identifiers and options.
+   * @since 0.16
+   */
+  public static SpanContext create(
+      TraceId traceId, SpanId spanId, TraceOptions traceOptions, Tracestate tracestate) {
+    return new SpanContextImpl(traceId, spanId, traceOptions, tracestate);
+  }
+
+  @Override
+  public String toTraceId() {
+      return traceId.toString(); // TODO: use a better value
+  }
+
+  @Override
+  public String toSpanId() {
+      return spanId.toString(); // TODO: same as above
+  }
+
+  /**
+   * Returns the trace identifier associated with this {@code SpanContext}.
+   *
+   * @return the trace identifier associated with this {@code SpanContext}.
+   * @since 0.5
+   */
+  public TraceId getTraceId() {
+    return traceId;
+  }
+
+  /**
+   * Returns the span identifier associated with this {@code SpanContext}.
+   *
+   * @return the span identifier associated with this {@code SpanContext}.
+   * @since 0.5
+   */
+  public SpanId getSpanId() {
+    return spanId;
+  }
+
+  /**
+   * Returns true if this {@code SpanContext} is valid.
+   *
+   * @return true if this {@code SpanContext} is valid.
+   * @since 0.5
+   */
+  @Override
+  public boolean isValid() {
+    return traceId.isValid() && spanId.isValid();
+  }
+
+  @Override
+  public boolean equals(@Nullable Object obj) {
+    if (obj == this) {
+      return true;
+    }
+
+    if (!(obj instanceof SpanContextImpl)) {
+      return false;
+    }
+
+    SpanContextImpl that = (SpanContextImpl) obj;
+    return traceId.equals(that.traceId)
+        && spanId.equals(that.spanId)
+        && traceOptions.equals(that.traceOptions);
+  }
+
+  @Override
+  public int hashCode() {
+    return Arrays.hashCode(new Object[] {traceId, spanId, traceOptions});
+  }
+
+  @Override
+  public String toString() {
+    return "SpanContext{traceId="
+        + traceId
+        + ", spanId="
+        + spanId
+        + ", traceOptions="
+        + traceOptions
+        + "}";
+  }
+
+  private SpanContextImpl(
+      TraceId traceId, SpanId spanId, TraceOptions traceOptions, Tracestate tracestate) {
+    super(traceOptions, tracestate);
+    this.traceId = traceId;
+    this.spanId = spanId;
+  }
+}

--- a/api/src/main/java/io/opencensus/trace/propagation/BinaryFormat.java
+++ b/api/src/main/java/io/opencensus/trace/propagation/BinaryFormat.java
@@ -18,6 +18,7 @@ package io.opencensus.trace.propagation;
 
 import io.opencensus.internal.Utils;
 import io.opencensus.trace.SpanContext;
+import io.opencensus.trace.SpanContextImpl;
 import java.text.ParseException;
 
 /**
@@ -148,7 +149,7 @@ public abstract class BinaryFormat {
     @Override
     public SpanContext fromByteArray(byte[] bytes) {
       Utils.checkNotNull(bytes, "bytes");
-      return SpanContext.INVALID;
+      return SpanContextImpl.INVALID;
     }
 
     private NoopBinaryFormat() {}

--- a/api/src/main/java/io/opencensus/trace/propagation/TextFormat.java
+++ b/api/src/main/java/io/opencensus/trace/propagation/TextFormat.java
@@ -19,6 +19,7 @@ package io.opencensus.trace.propagation;
 import io.opencensus.common.ExperimentalApi;
 import io.opencensus.internal.Utils;
 import io.opencensus.trace.SpanContext;
+import io.opencensus.trace.SpanContextImpl;
 import java.util.Collections;
 import java.util.List;
 import javax.annotation.Nullable;
@@ -198,7 +199,7 @@ public abstract class TextFormat {
     public <C /*>>> extends @NonNull Object*/> SpanContext extract(C carrier, Getter<C> getter) {
       Utils.checkNotNull(carrier, "carrier");
       Utils.checkNotNull(getter, "getter");
-      return SpanContext.INVALID;
+      return SpanContextImpl.INVALID;
     }
   }
 }

--- a/api/src/main/java/io/opencensus/trace/samplers/AlwaysSampleSampler.java
+++ b/api/src/main/java/io/opencensus/trace/samplers/AlwaysSampleSampler.java
@@ -36,8 +36,8 @@ final class AlwaysSampleSampler extends Sampler {
   public boolean shouldSample(
       @Nullable SpanContext parentContext,
       @Nullable Boolean hasRemoteParent,
-      TraceId traceId,
-      SpanId spanId,
+      Object traceId,
+      Object spanId,
       String name,
       List<Span> parentLinks) {
     return true;

--- a/api/src/main/java/io/opencensus/trace/samplers/NeverSampleSampler.java
+++ b/api/src/main/java/io/opencensus/trace/samplers/NeverSampleSampler.java
@@ -36,8 +36,8 @@ final class NeverSampleSampler extends Sampler {
   public boolean shouldSample(
       @Nullable SpanContext parentContext,
       @Nullable Boolean hasRemoteParent,
-      TraceId traceId,
-      SpanId spanId,
+      Object traceId,
+      Object spanId,
       String name,
       List<Span> parentLinks) {
     return false;

--- a/api/src/main/java/io/opencensus/trace/samplers/ProbabilitySampler.java
+++ b/api/src/main/java/io/opencensus/trace/samplers/ProbabilitySampler.java
@@ -74,8 +74,8 @@ abstract class ProbabilitySampler extends Sampler {
   public final boolean shouldSample(
       @Nullable SpanContext parentContext,
       @Nullable Boolean hasRemoteParent,
-      TraceId traceId,
-      SpanId spanId,
+      Object traceId,
+      Object spanId,
       String name,
       @Nullable List<Span> parentLinks) {
     // If the parent is sampled keep the sampling decision.
@@ -97,7 +97,7 @@ abstract class ProbabilitySampler extends Sampler {
     // while allowing for a (very) small chance of *not* sampling if the id == Long.MAX_VALUE.
     // This is considered a reasonable tradeoff for the simplicity/performance requirements (this
     // code is executed in-line for every Span creation).
-    return Math.abs(traceId.getLowerLong()) < getIdUpperBound();
+    return Math.abs(((TraceId)traceId).getLowerLong()) < getIdUpperBound();
   }
 
   @Override


### PR DESCRIPTION
This is an initial outline of the potential abstraction of Trace Identifiers (**in case** we decide not to go with W3C context **for now**). Observe I only did the refactor for the `api` module, as wanted to get some feedback before doing more refactoring here and there ;) Also, didn't touch the `TraceOptions` and `Tracestate` members for simplicity purposes.

Essentially: 

* The current `SpanContext` will become `SimpleContextImpl`, and actual implementation, and only string representations of the identifiers are exposed (for correlation purposes).
* `Link` now contains a `SpanContext` directly.
* Whenever users want to access the underneath trace identifiers implementation (and other related items), they would need to cast to their actual type.
* Probably the 'most' impacted area is the `Sampler` children, as they used to receive the `SpanId` and `TraceId` implementation in order to decide whether to sample or not. I used `Object` for them for now (`Object traceId`, etc), but we should later consider passing the `SpanContext` directly, or similar).